### PR TITLE
Unhandled hook that causes 0xc0000005 from RPCRT4.DLL intermittently.

### DIFF
--- a/loader/pico.spec
+++ b/loader/pico.spec
@@ -49,6 +49,7 @@ x64:
     addhook "KERNEL32$ExitThread"         "_ExitThread"
     addhook "KERNEL32$GetThreadContext"   "_GetThreadContext"
     addhook "KERNEL32$HeapAlloc"          "_HeapAlloc"
+    addhook "KERNEL32$HeapAlloc"          "_HeapReAlloc"
     addhook "KERNEL32$HeapFree"           "_HeapFree"
     addhook "KERNEL32$LoadLibraryA"       "_LoadLibraryA"
     addhook "KERNEL32$MapViewOfFile"      "_MapViewOfFile"

--- a/loader/src/pico.c
+++ b/loader/src/pico.c
@@ -11,6 +11,7 @@ DECLSPEC_IMPORT VOID   WINAPI KERNEL32$Sleep      ( DWORD );
 DECLSPEC_IMPORT VOID   WINAPI KERNEL32$ExitThread ( DWORD );
 DECLSPEC_IMPORT LPVOID WINAPI KERNEL32$HeapAlloc ( HANDLE, DWORD, SIZE_T );
 DECLSPEC_IMPORT BOOL   WINAPI KERNEL32$HeapFree  ( HANDLE, DWORD, LPVOID );
+DECLSPEC_IMPORT LPVOID WINAPI KERNEL32$HeapReAlloc  ( HANDLE, DWORD, LPVOID, SIZE_T );
 
 FARPROC WINAPI _GetProcAddress ( HMODULE hModule, LPCSTR lpProcName )
 {
@@ -119,6 +120,47 @@ LPVOID WINAPI _HeapAlloc ( HANDLE hHeap, DWORD dwFlags, SIZE_T dwBytes )
 
     return result;
 }
+
+// Fixes random crashes that occur inside RPCRT4.DLL
+LPVOID WINAPI _HeapReAlloc ( HANDLE hHeap, DWORD dwFlags, LPVOID lpMem, SIZE_T dwBytes )
+{
+    FUNCTION_CALL call = { 0 };
+
+    call.ptr        = ( PVOID ) ( KERNEL32$HeapReAlloc );
+    call.argc       = 4;
+    call.args [ 0 ] = spoof_arg ( hHeap );
+    call.args [ 1 ] = spoof_arg ( dwFlags );
+    call.args [ 2 ] = spoof_arg ( lpMem );
+    call.args [ 3 ] = spoof_arg ( dwBytes );
+
+    LPVOID result = ( LPVOID ) spoof_call ( &call );
+
+    if ( result )
+    {
+        BOOL found = FALSE;
+
+        for ( int i = 0; i < g_memory.Heap.Count; i++ )
+        {
+            if ( g_memory.Heap.Records [ i ].Address == lpMem )
+            {
+                g_memory.Heap.Records [ i ].Address = result;
+                g_memory.Heap.Records [ i ].Size    = dwBytes;
+                found = TRUE;
+                break;
+            }
+        }
+
+        if ( !found && dwBytes >= 256 && g_memory.Heap.Count < MAX_HEAP_RECORDS )
+        {
+            g_memory.Heap.Records [ g_memory.Heap.Count ].Address = result;
+            g_memory.Heap.Records [ g_memory.Heap.Count ].Size    = dwBytes;
+            g_memory.Heap.Count++;
+        }
+    }
+
+    return result;
+}
+
 
 BOOL WINAPI _HeapFree ( HANDLE hHeap, DWORD dwFlags, LPVOID lpMem )
 {

--- a/loader/src/pico.c
+++ b/loader/src/pico.c
@@ -7,11 +7,11 @@
 
 MEMORY_LAYOUT g_memory;
 
-DECLSPEC_IMPORT VOID   WINAPI KERNEL32$Sleep      ( DWORD );
-DECLSPEC_IMPORT VOID   WINAPI KERNEL32$ExitThread ( DWORD );
-DECLSPEC_IMPORT LPVOID WINAPI KERNEL32$HeapAlloc ( HANDLE, DWORD, SIZE_T );
-DECLSPEC_IMPORT BOOL   WINAPI KERNEL32$HeapFree  ( HANDLE, DWORD, LPVOID );
-DECLSPEC_IMPORT LPVOID WINAPI KERNEL32$HeapReAlloc  ( HANDLE, DWORD, LPVOID, SIZE_T );
+DECLSPEC_IMPORT VOID   WINAPI KERNEL32$Sleep       ( DWORD );
+DECLSPEC_IMPORT VOID   WINAPI KERNEL32$ExitThread  ( DWORD );
+DECLSPEC_IMPORT LPVOID WINAPI KERNEL32$HeapAlloc   ( HANDLE, DWORD, SIZE_T );
+DECLSPEC_IMPORT BOOL   WINAPI KERNEL32$HeapFree    ( HANDLE, DWORD, LPVOID );
+DECLSPEC_IMPORT LPVOID WINAPI KERNEL32$HeapReAlloc ( HANDLE, DWORD, LPVOID, SIZE_T );
 
 FARPROC WINAPI _GetProcAddress ( HMODULE hModule, LPCSTR lpProcName )
 {
@@ -101,8 +101,9 @@ LPVOID WINAPI _HeapAlloc ( HANDLE hHeap, DWORD dwFlags, SIZE_T dwBytes )
 
     FUNCTION_CALL call = { 0 };
 
-    call.ptr        = ( PVOID ) ( KERNEL32$HeapAlloc );
-    call.argc       = 3;
+    call.ptr  = ( PVOID ) ( KERNEL32$HeapAlloc );
+    call.argc = 3;
+    
     call.args [ 0 ] = spoof_arg ( hHeap );
     call.args [ 1 ] = spoof_arg ( dwFlags );
     call.args [ 2 ] = spoof_arg ( dwBytes );
@@ -121,13 +122,13 @@ LPVOID WINAPI _HeapAlloc ( HANDLE hHeap, DWORD dwFlags, SIZE_T dwBytes )
     return result;
 }
 
-// Fixes random crashes that occur inside RPCRT4.DLL
 LPVOID WINAPI _HeapReAlloc ( HANDLE hHeap, DWORD dwFlags, LPVOID lpMem, SIZE_T dwBytes )
 {
     FUNCTION_CALL call = { 0 };
 
-    call.ptr        = ( PVOID ) ( KERNEL32$HeapReAlloc );
-    call.argc       = 4;
+    call.ptr  = ( PVOID ) ( KERNEL32$HeapReAlloc );
+    call.argc = 4;
+    
     call.args [ 0 ] = spoof_arg ( hHeap );
     call.args [ 1 ] = spoof_arg ( dwFlags );
     call.args [ 2 ] = spoof_arg ( lpMem );
@@ -166,8 +167,9 @@ BOOL WINAPI _HeapFree ( HANDLE hHeap, DWORD dwFlags, LPVOID lpMem )
 {
     FUNCTION_CALL call = { 0 };
 
-    call.ptr        = ( PVOID ) ( KERNEL32$HeapFree );
-    call.argc       = 3;
+    call.ptr  = ( PVOID ) ( KERNEL32$HeapFree );
+    call.argc = 3;
+    
     call.args [ 0 ] = spoof_arg ( hHeap );
     call.args [ 1 ] = spoof_arg ( dwFlags );
     call.args [ 2 ] = spoof_arg ( lpMem );


### PR DESCRIPTION
After an initial callback an Access Violation would be thrown from RPCRT4.DLL that seems related to an unhandled hook for HeapReAlloc. After adding this hook it no longer encounters this exception.