### PR TITLE
Fix duplicate hook for HeapAlloc in pico.spec

### DIFF
--- a/loader/pico.spec
+++ b/loader/pico.spec
@@ -49,7 +49,7 @@ x64:
     addhook "KERNEL32$ExitThread"         "_ExitThread"
     addhook "KERNEL32$GetThreadContext"   "_GetThreadContext"
     addhook "KERNEL32$HeapAlloc"          "_HeapAlloc"
-    addhook "KERNEL32$HeapReAlloc"          "_HeapReAlloc"
+    addhook "KERNEL32$HeapReAlloc"        "_HeapReAlloc"
     addhook "KERNEL32$HeapFree"           "_HeapFree"
     addhook "KERNEL32$LoadLibraryA"       "_LoadLibraryA"
     addhook "KERNEL32$MapViewOfFile"      "_MapViewOfFile"

--- a/loader/pico.spec
+++ b/loader/pico.spec
@@ -49,7 +49,7 @@ x64:
     addhook "KERNEL32$ExitThread"         "_ExitThread"
     addhook "KERNEL32$GetThreadContext"   "_GetThreadContext"
     addhook "KERNEL32$HeapAlloc"          "_HeapAlloc"
-    addhook "KERNEL32$HeapAlloc"          "_HeapReAlloc"
+    addhook "KERNEL32$HeapReAlloc"          "_HeapReAlloc"
     addhook "KERNEL32$HeapFree"           "_HeapFree"
     addhook "KERNEL32$LoadLibraryA"       "_LoadLibraryA"
     addhook "KERNEL32$MapViewOfFile"      "_MapViewOfFile"


### PR DESCRIPTION
Hey, I noticed that there is a minor bug where `KERNEL32$HeapAlloc` is defined twice for `_HeapAlloc` and `_HeapReAlloc` in the `pico.spec` file, causing the loader to crash upon Beacon DLL execution. This commit updates the spec to define the hooks as expected.